### PR TITLE
Add virtual AST_CLOSURE_VAR node

### DIFF
--- a/ast_data.c
+++ b/ast_data.c
@@ -100,6 +100,7 @@ const zend_ast_kind ast_kinds[] = {
 	ZEND_AST_FOR,
 	ZEND_AST_FOREACH,
 	AST_NAME,
+	AST_CLOSURE_VAR
 };
 
 const char *ast_kind_to_name(zend_ast_kind kind) {
@@ -201,6 +202,7 @@ const char *ast_kind_to_name(zend_ast_kind kind) {
 		case ZEND_AST_FOR: return "AST_FOR";
 		case ZEND_AST_FOREACH: return "AST_FOREACH";
 		case AST_NAME: return "AST_NAME";
+		case AST_CLOSURE_VAR: return "AST_CLOSURE_VAR";
 	}
 
 	return NULL;
@@ -304,4 +306,5 @@ void ast_register_kind_constants(INIT_FUNC_ARGS) {
 	REGISTER_NS_LONG_CONSTANT("ast", "AST_FOR", ZEND_AST_FOR, CONST_CS | CONST_PERSISTENT);
 	REGISTER_NS_LONG_CONSTANT("ast", "AST_FOREACH", ZEND_AST_FOREACH, CONST_CS | CONST_PERSISTENT);
 	REGISTER_NS_LONG_CONSTANT("ast", "AST_NAME", AST_NAME, CONST_CS | CONST_PERSISTENT);
+	REGISTER_NS_LONG_CONSTANT("ast", "AST_CLOSURE_VAR", AST_CLOSURE_VAR, CONST_CS | CONST_PERSISTENT);
 }

--- a/php_ast.h
+++ b/php_ast.h
@@ -41,6 +41,7 @@ ZEND_END_MODULE_GLOBALS(ast)
 
 /* Custom ast kind for names */
 #define AST_NAME 2048
+#define AST_CLOSURE_VAR 2049
 
 extern const size_t ast_kinds_count;
 extern const zend_ast_kind ast_kinds[];


### PR DESCRIPTION
Without this you couldn't distinguish a by-ref closure use var