### PR TITLE
Added support for flag names in AST_INCLUDE_OR_EVAL nodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,11 @@ T_FUNCTION
 T_CONST
 
 // Used by ast\AST_INCLUDE_OR_EVAL (exclusive)
-ast\flags\???
+ast\flags\EXEC_EVAL
+ast\flags\EXEC_INCLUDE
+ast\flags\EXEC_INCLUDE_ONCE
+ast\flags\EXEC_REQUIRE
+ast\flags\EXEC_REQUIRE_ONCE
 ```
 
   [parser]: http://lxr.php.net/xref/PHP_TRUNK/Zend/zend_language_parser.y

--- a/ast.c
+++ b/ast.c
@@ -448,6 +448,12 @@ PHP_MINIT_FUNCTION(ast) {
 	ast_register_flag_constant("ASSIGN_SHIFT_LEFT", ZEND_ASSIGN_SL);
 	ast_register_flag_constant("ASSIGN_SHIFT_RIGHT", ZEND_ASSIGN_SR);
 
+	ast_register_flag_constant("EXEC_EVAL", ZEND_EVAL);
+	ast_register_flag_constant("EXEC_INCLUDE", ZEND_INCLUDE);
+	ast_register_flag_constant("EXEC_INCLUDE_ONCE", ZEND_INCLUDE_ONCE);
+	ast_register_flag_constant("EXEC_REQUIRE", ZEND_REQUIRE);
+	ast_register_flag_constant("EXEC_REQUIRE_ONCE", ZEND_REQUIRE_ONCE);
+
 	INIT_CLASS_ENTRY(tmp_ce, "ast\\Node", NULL);
 	ast_node_ce = zend_register_internal_class(&tmp_ce);
 

--- a/util.php
+++ b/util.php
@@ -106,6 +106,13 @@ function get_flag_info() : array {
         ast\AST_USE => $useTypes,
         ast\AST_GROUP_USE => $useTypes,
         ast\AST_USE_ELEM => $useTypes,
+        ast\AST_INCLUDE_OR_EVAL => [
+            flags\EXEC_EVAL => 'EXEC_EVAL',
+            flags\EXEC_INCLUDE => 'EXEC_INCLUDE',
+            flags\EXEC_INCLUDE_ONCE => 'EXEC_INCLUDE_ONCE',
+            flags\EXEC_REQUIRE => 'EXEC_REQUIRE',
+            flags\EXEC_REQUIRE_ONCE => 'EXEC_REQUIRE_ONCE',
+        ],
     ];
 
     $combinable = [];


### PR DESCRIPTION
As stated in the README, for most nodes, `flags` is always `0`. Some nodes use flags, and this is also clearly defined at the end of the README. I noticed that the flags for `AST_INCLUDE_OR_EVAL` nodes were not described, that `util.php`'s `format_flags()` function cannot format them, and that no appropriate flag constants were even defined by the extension. Yet flags for `AST_INCLUDE_OR_EVAL` do indeed exist, for example the following code...

```
eval( 'echo "hello";');
include 'foo.php';
include_once 'foo.php';
require 'foo.php';
require_once 'foo.php';
```

currently yields:

```
AST_STMT_LIST      
    0: AST_INCLUDE_OR_EVAL
        flags: 1   
        0: "echo "hello";"
    1: AST_INCLUDE_OR_EVAL
        flags: 2   
        0: "foo.php"
    2: AST_INCLUDE_OR_EVAL
        flags: 4   
        0: "foo.php"
    3: AST_INCLUDE_OR_EVAL
        flags: 8
        0: "foo.php"
    4: AST_INCLUDE_OR_EVAL
        flags: 16
        0: "foo.php"
```

With this pull request, it will instead yield:

```
AST_STMT_LIST
    0: AST_INCLUDE_OR_EVAL
        flags: EXEC_EVAL (1)
        0: "echo "hello";"
    1: AST_INCLUDE_OR_EVAL
        flags: EXEC_INCLUDE (2)
        0: "foo.php"
    2: AST_INCLUDE_OR_EVAL
        flags: EXEC_INCLUDE_ONCE (4)
        0: "foo.php"
    3: AST_INCLUDE_OR_EVAL
        flags: EXEC_REQUIRE (8)
        0: "foo.php"
    4: AST_INCLUDE_OR_EVAL
        flags: EXEC_REQUIRE_ONCE (16)
        0: "foo.php"
```

The flags' integral values match the values defined in `Zend/zend_compile.h`.

