### PR TITLE
Use AST_VAR node for AST_PARAM and AST_PROP_ELEM children

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -134,7 +134,9 @@ static inline zend_bool ast_is_name(zend_ast *ast, zend_ast *parent, uint32_t i)
 
 static inline zend_bool ast_is_var_name(zend_ast *ast, zend_ast *parent, uint32_t i) {
 	return (parent->kind == ZEND_AST_STATIC && i == 0)
-		|| (parent->kind == ZEND_AST_CATCH && i == 1);
+		|| (parent->kind == ZEND_AST_CATCH && i == 1)
+		|| (parent->kind == ZEND_AST_PARAM && i == 1)
+		|| (parent->kind == ZEND_AST_PROP_ELEM && i == 0);
 }
 
 static inline zend_ast_attr ast_assign_op_to_binary_op(zend_ast_attr attr) {

--- a/ast_data.c
+++ b/ast_data.c
@@ -562,7 +562,7 @@ zend_string *ast_kind_child_name(zend_ast_kind kind, uint32_t child) {
 			return NULL;
 		case ZEND_AST_PROP_ELEM:
 			switch (child) {
-				case 0: return AST_STR(name);
+				case 0: return AST_STR(var);
 				case 1: return AST_STR(default);
 			}
 			return NULL;
@@ -652,7 +652,7 @@ zend_string *ast_kind_child_name(zend_ast_kind kind, uint32_t child) {
 		case ZEND_AST_PARAM:
 			switch (child) {
 				case 0: return AST_STR(type);
-				case 1: return AST_STR(name);
+				case 1: return AST_STR(var);
 				case 2: return AST_STR(default);
 			}
 			return NULL;

--- a/generate_ast_data.php
+++ b/generate_ast_data.php
@@ -120,7 +120,7 @@ $names = [
     'ZEND_AST_SWITCH' => ['cond', 'stmts'],
     'ZEND_AST_SWITCH_CASE' => ['cond', 'stmts'],
     'ZEND_AST_DECLARE' => ['declares', 'stmts'],
-    'ZEND_AST_PROP_ELEM' => ['name', 'default'],
+    'ZEND_AST_PROP_ELEM' => ['var', 'default'],
     'ZEND_AST_CONST_ELEM' => ['name', 'value'],
     'ZEND_AST_USE_TRAIT' => ['traits', 'adaptations'],
     'ZEND_AST_TRAIT_PRECEDENCE' => ['method', 'insteadof'],
@@ -137,7 +137,7 @@ $names = [
 
     'ZEND_AST_TRY' => ['tryStmts', 'catches', 'finallyStmts'],
     'ZEND_AST_CATCH' => ['exception', 'var', 'stmts'],
-    'ZEND_AST_PARAM' => ['type', 'name', 'default'],
+    'ZEND_AST_PARAM' => ['type', 'var', 'default'],
 
     /* 4 child nodes */
     'ZEND_AST_FOR' => ['init', 'cond', 'loop', 'stmts'],


### PR DESCRIPTION
Hi Nikita!

I noticed that your recent commit (5694d066f30565cedfd0a32e872f9c702b3d1cc2) made nodes whose children were variables to use AST_VAR for better consistency. This PR applies it to the AST_PARAM and AST_PROP_ELEM children too. The only other node that has variables for children (that aren't AST_VAR) is AST_CLOSURE_VAR, which I wasn't too sure about whether to change or leave as-is (since it makes sense either way, IMO).

Thanks,
Tom