### PR TITLE
util.php need tokenizer extension

### DIFF
--- a/tests/001.phpt
+++ b/tests/001.phpt
@@ -1,7 +1,10 @@
 --TEST--
 ast_dump() test
 --SKIPIF--
-<?php if (!extension_loaded("ast")) print "skip"; ?>
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php 
 

--- a/tests/assign_ops.phpt
+++ b/tests/assign_ops.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Assign op flags
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/ast_dump_with_linenos.phpt
+++ b/tests/ast_dump_with_linenos.phpt
@@ -1,7 +1,10 @@
 --TEST--
 ast_dump() with AST_DUMP_LINENOS
 --SKIPIF--
-<?php if (!extension_loaded("ast")) print "skip"; ?>
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/binary_ops.phpt
+++ b/tests/binary_ops.phpt
@@ -1,5 +1,10 @@
 --TEST--
 AST_GREATER(_EQUAL) converted to AST_BINARY_OP
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/class.phpt
+++ b/tests/class.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Test parse and dump of class
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/class_types.phpt
+++ b/tests/class_types.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Different class types
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/closure_use_vars.phpt
+++ b/tests/closure_use_vars.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Closure uses should parse to CLOSURE_USE_VAR nodes
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/eval_include.phpt
+++ b/tests/eval_include.phpt
@@ -1,5 +1,10 @@
 --TEST--
 eval() and include parsing
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/named_children.phpt
+++ b/tests/named_children.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Named child nodes
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/nested_stat_lists.phpt
+++ b/tests/nested_stat_lists.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Nested statement lists
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/parse_file.phpt
+++ b/tests/parse_file.phpt
@@ -1,5 +1,10 @@
 --TEST--
 ast\parse_file() on valid file
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/prop_doc_comments.phpt
+++ b/tests/prop_doc_comments.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Doc comments on properties
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/try_catch_finally.phpt
+++ b/tests/try_catch_finally.phpt
@@ -1,5 +1,10 @@
 --TEST--
 try / catch / finally
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/unary_ops.phpt
+++ b/tests/unary_ops.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Convert unary ops AST_(SILENCE|UNARY_(PLUS|MINUS)) to flags of ZEND_AST_UNARY_OP
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 

--- a/tests/use_declarations.phpt
+++ b/tests/use_declarations.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Test parse and dump of use declarations
+--SKIPIF--
+<?php
+if (!extension_loaded("ast")) print "skip ast extension not loaded";
+if (!extension_loaded("tokenizer")) print "skip tokenizer extension not loaded";
+?>
 --FILE--
 <?php
 


### PR DESCRIPTION
As tokenizer extension can be build shared, could be unavailable during make test.
So skip these tests if extension is not loaded.