### PR TITLE
Add second parameter $version to parse_code()

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $code = <<<'EOC'
 $var = 42;
 EOC;
 
-var_dump(ast\parse_code($code));
+var_dump(ast\parse_code($code, 20));
 
 // Output:
 object(ast\Node)#1 (4) {
@@ -159,7 +159,7 @@ $code = <<<'EOC'
 $var = 42;
 EOC;
 
-echo ast_dump(ast\parse_code($code)), "\n";
+echo ast_dump(ast\parse_code($code, 20)), "\n";
 
 // Output:
 AST_STMT_LIST


### PR DESCRIPTION
The method `parse_code()` requires the second parameter `$version`, but it is missing in some examples. The commit fixes this.