### PR TITLE
Update display of extension in phpinfo()

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -730,7 +730,7 @@ const zend_function_entry ast_functions[] = {
 
 PHP_MINFO_FUNCTION(ast) {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "ast support", "enabled");
+	php_info_print_table_row(2, "ast support", "enabled");
 	php_info_print_table_end();
 }
 


### PR DESCRIPTION
Most extensions use `php_info_print_table_row()` instead of `php_info_print_table_header()` to show that the extension is loaded in the `phpinfo()` output. :)

<img width="956" alt="screen shot 2016-12-13 at 6 52 44 am" src="https://cloud.githubusercontent.com/assets/578780/21141096/f67a193a-c100-11e6-9f2d-2d6558d4fc27.png">

This just makes the output more uniform and easier to scan.