### PR TITLE
Add a unique closure id to Nodes in version 45+

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ AST_INCLUDE_OR_EVAL:  expr
 AST_INSTANCEOF:       expr, class
 AST_ISSET:            var
 AST_LABEL:            name
-AST_MAGIC_CONST:      
+AST_MAGIC_CONST:
 AST_METHOD:           params, uses, stmts, returnType
 AST_METHOD_CALL:      expr, method, args
 AST_METHOD_REFERENCE: class, method
@@ -388,7 +388,7 @@ AST_THROW:            expr
 AST_TRAIT_ALIAS:      method, alias
 AST_TRAIT_PRECEDENCE: method, insteadof
 AST_TRY:              try, catches, finally
-AST_TYPE:             
+AST_TYPE:
 AST_UNARY_MINUS:      expr                   // prior to version 20
 AST_UNARY_OP:         expr
 AST_UNARY_PLUS:       expr                   // prior to version 20
@@ -423,6 +423,10 @@ ZEND_AST_USE
 
 Version changelog
 -----------------
+### 45 (in development)
+
+* An integer `__closureId` has been added to Nodes for closures.
+  The combination of `lineno` and `__closureId` is guaranteed to uniquely identify a closure.
 
 ### 40 (current)
 

--- a/README.md
+++ b/README.md
@@ -425,8 +425,10 @@ Version changelog
 -----------------
 ### 45 (in development)
 
-* An integer `__closureId` has been added to Nodes for closures.
-  The combination of `lineno` and `__closureId` is guaranteed to uniquely identify a closure.
+* An integer `__declId` has been added to nodes that were of type Decl (e.g. function/method/closure/class) (And to all preceding versions).
+  The combination of `lineno` and `__declId` is guaranteed to uniquely identify a declaration within the parsed code
+  and will remain the same if the code is parsed again. (E.g. this may be useful for distinguishing closures declared on the same line)
+  NOTE: this is added by the php-ast extension (not part of the AST) and the implementation may be changed later on to use something else, such as a column number.
 
 ### 40 (current)
 

--- a/ast.c
+++ b/ast.c
@@ -54,7 +54,7 @@
 
 /* This contains mutable state of the ast Node creator. */
 typedef struct ast_state_info {
-	zend_long closureIdCounter;
+	zend_long declIdCounter;
 } ast_state_info_t;
 
 static inline void ast_update_property(zval *object, zend_string *name, zval *value, void **cache_slot) {
@@ -439,11 +439,11 @@ static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, zend_long version
 		}
 
 	}
-	if (version >= 45 && ast->kind == ZEND_AST_CLOSURE) {
+	if (ast_kind_is_decl(ast->kind)) {
 		zval id_zval;
-		ZVAL_LONG(&id_zval, state->closureIdCounter);
-		state->closureIdCounter++;
-		zend_hash_add_new(ht, AST_STR(str___closureId), &id_zval);
+		ZVAL_LONG(&id_zval, state->declIdCounter);
+		state->declIdCounter++;
+		zend_hash_add_new(ht, AST_STR(str___declId), &id_zval);
 	}
 }
 
@@ -658,7 +658,7 @@ PHP_FUNCTION(parse_file) {
 		zend_string_free(code);
 		return;
 	}
-	state.closureIdCounter = 0;
+	state.declIdCounter = 0;
 
 	ast_to_zval(return_value, ast, version, &state);
 
@@ -687,7 +687,7 @@ PHP_FUNCTION(parse_code) {
 		return;
 	}
 
-	state.closureIdCounter = 0;
+	state.declIdCounter = 0;
 	ast_to_zval(return_value, ast, version, &state);
 
 	zend_ast_destroy(ast);

--- a/ast.c
+++ b/ast.c
@@ -52,6 +52,11 @@
 # define ZEND_ARRAY_SYNTAX_SHORT 3
 #endif
 
+/* This contains mutable state of the ast Node creator. */
+typedef struct ast_state_info {
+	zend_long closureIdCounter;
+} ast_state_info_t;
+
 static inline void ast_update_property(zval *object, zend_string *name, zval *value, void **cache_slot) {
 	zval name_zv;
 	ZVAL_STR(&name_zv, name);
@@ -272,11 +277,11 @@ static inline zend_ast **ast_get_children(zend_ast *ast, uint32_t *count) {
 	}
 }
 
-static void ast_to_zval(zval *zv, zend_ast *ast, zend_long version);
+static void ast_to_zval(zval *zv, zend_ast *ast, zend_long version, ast_state_info_t *state);
 
 static void ast_create_virtual_node_ex(
 		zval *zv, zend_ast_kind kind, zend_ast_attr attr, uint32_t lineno,
-		zend_long version, uint32_t num_children, ...) {
+		zend_long version, ast_state_info_t *state, uint32_t num_children, ...) {
 	zval tmp_zv;
 	va_list va;
 	uint32_t i;
@@ -307,14 +312,14 @@ static void ast_create_virtual_node_ex(
 }
 
 static void ast_create_virtual_node(
-		zval *zv, zend_ast_kind kind, zend_ast_attr attr, zend_ast *child, zend_long version) {
+		zval *zv, zend_ast_kind kind, zend_ast_attr attr, zend_ast *child, zend_long version, ast_state_info_t *state) {
 	zval child_zv;
-	ast_to_zval(&child_zv, child, version);
+	ast_to_zval(&child_zv, child, version, state);
 	return ast_create_virtual_node_ex(
-		zv, kind, attr, zend_ast_get_lineno(child), version, 1, &child_zv);
+		zv, kind, attr, zend_ast_get_lineno(child), version, state, 1, &child_zv);
 }
 
-static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, zend_long version) {
+static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, zend_long version, ast_state_info_t *state) {
 	uint32_t i, count;
 	zend_bool is_list = zend_ast_is_list(ast);
 	zend_ast **children = ast_get_children(ast, &count);
@@ -325,7 +330,7 @@ static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, zend_long version
 
 		if (ast->kind == ZEND_AST_STMT_LIST) {
 			if (child != NULL && child->kind == ZEND_AST_STMT_LIST) {
-				ast_fill_children_ht(ht, child, version);
+				ast_fill_children_ht(ht, child, version, state);
 				continue;
 			}
 			if (version >= 40 && child == NULL) {
@@ -340,15 +345,15 @@ static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, zend_long version
 			/* Emulate PHP 7.0 format (no list) */
 			zend_ast *first_child = zend_ast_get_list(child)->child[0];
 			ast_create_virtual_node(
-				&child_zv, AST_NAME, first_child->attr, first_child, version);
+				&child_zv, AST_NAME, first_child->attr, first_child, version, state);
 		}
 #else
 		if (ast->kind == ZEND_AST_CATCH && version >= 35 && i == 0) {
 			/* Emulate PHP 7.1 format (name list) */
 			zval tmp;
-			ast_create_virtual_node(&tmp, AST_NAME, child->attr, child, version);
+			ast_create_virtual_node(&tmp, AST_NAME, child->attr, child, version, state);
 			ast_create_virtual_node_ex(
-				&child_zv, ZEND_AST_NAME_LIST, 0, zend_ast_get_lineno(child), version, 1, &tmp);
+				&child_zv, ZEND_AST_NAME_LIST, 0, zend_ast_get_lineno(child), version, state, 1, &tmp);
 		}
 #endif
 		else if (ast_is_name(child, ast, i)) {
@@ -375,9 +380,9 @@ static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, zend_long version
 					&& (type = lookup_builtin_type(zend_ast_get_str(child)))) {
 				/* Convert "int" etc typehints to TYPE nodes */
 				ast_create_virtual_node_ex(
-					&child_zv, ZEND_AST_TYPE, type, zend_ast_get_lineno(child), version, 0);
+					&child_zv, ZEND_AST_TYPE, type, zend_ast_get_lineno(child), version, state, 0);
 			} else {
-				ast_create_virtual_node(&child_zv, AST_NAME, child->attr, child, version);
+				ast_create_virtual_node(&child_zv, AST_NAME, child->attr, child, version, state);
 			}
 
 			if (is_nullable) {
@@ -385,24 +390,24 @@ static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, zend_long version
 				zval tmp;
 				ZVAL_COPY_VALUE(&tmp, &child_zv);
 				ast_create_virtual_node_ex(
-					&child_zv, AST_NULLABLE_TYPE, 0, zend_ast_get_lineno(child), version, 1, &tmp);
+					&child_zv, AST_NULLABLE_TYPE, 0, zend_ast_get_lineno(child), version, state, 1, &tmp);
 			}
 		} else if (child && child->kind == ZEND_AST_TYPE && (child->attr & ZEND_TYPE_NULLABLE)) {
 			child->attr &= ~ZEND_TYPE_NULLABLE;
-			ast_create_virtual_node(&child_zv, AST_NULLABLE_TYPE, 0, child, version);
+			ast_create_virtual_node(&child_zv, AST_NULLABLE_TYPE, 0, child, version, state);
 		} else if (ast->kind == ZEND_AST_CLOSURE_USES) {
-			ast_create_virtual_node(&child_zv, AST_CLOSURE_VAR, child->attr, child, version);
+			ast_create_virtual_node(&child_zv, AST_CLOSURE_VAR, child->attr, child, version, state);
 		} else if (ast_is_var_name(child, ast, i)) {
-			ast_create_virtual_node(&child_zv, ZEND_AST_VAR, 0, child, version);
+			ast_create_virtual_node(&child_zv, ZEND_AST_VAR, 0, child, version, state);
 		} else if (version >= 40 && ast_should_normalize_list(child, ast, i)) {
 			if (child) {
 				zval tmp;
-				ast_to_zval(&tmp, child, version);
+				ast_to_zval(&tmp, child, version, state);
 				ast_create_virtual_node_ex(
-					&child_zv, ZEND_AST_STMT_LIST, 0, zend_ast_get_lineno(child), version, 1, &tmp);
+					&child_zv, ZEND_AST_STMT_LIST, 0, zend_ast_get_lineno(child), version, state, 1, &tmp);
 			} else {
 				ast_create_virtual_node_ex(
-					&child_zv, ZEND_AST_STMT_LIST, 0, zend_ast_get_lineno(ast), version, 0);
+					&child_zv, ZEND_AST_STMT_LIST, 0, zend_ast_get_lineno(ast), version, state, 0);
 			}
 		} else if (i == 2
 				&& (ast->kind == ZEND_AST_PROP_ELEM || ast->kind == ZEND_AST_CONST_ELEM)) {
@@ -411,20 +416,20 @@ static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, zend_long version
 #if PHP_VERSION_ID >= 70100
 		} else if (ast->kind == ZEND_AST_LIST && child != NULL) {
 			/* Emulate simple variable list */
-			ast_to_zval(&child_zv, child->child[0], version);
+			ast_to_zval(&child_zv, child->child[0], version, state);
 #else
 		} else if (version >= 35 && ast->kind == ZEND_AST_ARRAY
 				&& ast->attr == ZEND_ARRAY_SYNTAX_LIST && child != NULL) {
 			/* Emulate ARRAY_ELEM list */
 			zval ch0, ch1;
-			ast_to_zval(&ch0, child, version);
+			ast_to_zval(&ch0, child, version, state);
 			ZVAL_NULL(&ch1);
 			ast_create_virtual_node_ex(
-				&child_zv, ZEND_AST_ARRAY_ELEM, 0, zend_ast_get_lineno(child), version,
+				&child_zv, ZEND_AST_ARRAY_ELEM, 0, zend_ast_get_lineno(child), version, state,
 				2, &ch0, &ch1);
 #endif
 		} else {
-			ast_to_zval(&child_zv, child, version);
+			ast_to_zval(&child_zv, child, version, state);
 		}
 
 		if (child_name) {
@@ -434,9 +439,15 @@ static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, zend_long version
 		}
 
 	}
+	if (version >= 45 && ast->kind == ZEND_AST_CLOSURE) {
+		zval id_zval;
+		ZVAL_LONG(&id_zval, state->closureIdCounter);
+		state->closureIdCounter++;
+		zend_hash_add_new(ht, AST_STR(str___closureId), &id_zval);
+	}
 }
 
-static void ast_to_zval(zval *zv, zend_ast *ast, zend_long version) {
+static void ast_to_zval(zval *zv, zend_ast *ast, zend_long version, ast_state_info_t *state) {
 	zval tmp_zv;
 	zend_bool is_decl;
 
@@ -554,10 +565,10 @@ static void ast_to_zval(zval *zv, zend_ast *ast, zend_long version) {
 	Z_DELREF(tmp_zv);
 	ast_update_property(zv, AST_STR(str_children), &tmp_zv, AST_CACHE_SLOT_CHILDREN);
 
-	ast_fill_children_ht(Z_ARRVAL(tmp_zv), ast, version);
+	ast_fill_children_ht(Z_ARRVAL(tmp_zv), ast, version, state);
 }
 
-static const zend_long versions[] = {30, 35, 40};
+static const zend_long versions[] = {30, 35, 40, 45};
 static const size_t versions_count = sizeof(versions)/sizeof(versions[0]);
 
 static zend_string *ast_version_info() {
@@ -613,6 +624,7 @@ static int ast_check_version(zend_long version) {
 PHP_FUNCTION(parse_file) {
 	zend_string *filename, *code;
 	zend_long version = -1;
+	ast_state_info_t state;
 	zend_ast *ast;
 	zend_arena *arena;
 	php_stream *stream;
@@ -646,8 +658,9 @@ PHP_FUNCTION(parse_file) {
 		zend_string_free(code);
 		return;
 	}
+	state.closureIdCounter = 0;
 
-	ast_to_zval(return_value, ast, version);
+	ast_to_zval(return_value, ast, version, &state);
 
 	zend_string_free(code);
 	zend_ast_destroy(ast);
@@ -657,6 +670,7 @@ PHP_FUNCTION(parse_file) {
 PHP_FUNCTION(parse_code) {
 	zend_string *code, *filename = NULL;
 	zend_long version = -1;
+	ast_state_info_t state;
 	zend_ast *ast;
 	zend_arena *arena;
 
@@ -673,7 +687,8 @@ PHP_FUNCTION(parse_code) {
 		return;
 	}
 
-	ast_to_zval(return_value, ast, version);
+	state.closureIdCounter = 0;
+	ast_to_zval(return_value, ast, version, &state);
 
 	zend_ast_destroy(ast);
 	zend_arena_destroy(arena);

--- a/ast_str_defs.h
+++ b/ast_str_defs.h
@@ -46,6 +46,6 @@
 	X(finally) \
 	X(init) \
 	X(loop) \
-	X(__closureId) \
+	X(__declId) \
 
 #endif

--- a/ast_str_defs.h
+++ b/ast_str_defs.h
@@ -46,5 +46,6 @@
 	X(finally) \
 	X(init) \
 	X(loop) \
+	X(__closureId) \
 
 #endif

--- a/package.xml
+++ b/package.xml
@@ -25,9 +25,9 @@
  <notes>
 - Fix issue #51: Make nullable array/callable have a flag of 0 in inner element, in version 40.
 - Added a constructor for the ast\Node class.
-- Start implementing AST version 45 (currently experimental).
-- Add __closureId to info about closure Nodes, to make it easier for php-ast callers
-  to process Nodes with multiple closures on the same line.
+- Start implementing AST version 45 (currently under development).
+- Add __declId to info about Decl nodes (all versions), to make it easier for php-ast callers
+  to process multiple similar Decl definitions (e.g. closures) on the same line.
  </notes>
  <contents>
   <dir name="/">

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,9 @@
  <notes>
 - Fix issue #51: Make nullable array/callable have a flag of 0 in inner element, in version 40.
 - Added a constructor for the ast\Node class.
+- Start implementing AST version 45 (currently experimental).
+- Add __closureId to info about closure Nodes, to make it easier for php-ast callers
+  to process Nodes with multiple closures on the same line.
  </notes>
  <contents>
   <dir name="/">
@@ -51,6 +54,7 @@
       <file name="class.phpt" role="test" />
       <file name="class_types.phpt" role="test" />
       <file name="closure_use_vars.phpt" role="test" />
+      <file name="closure_numbers.phpt" role="test" />
       <file name="coalesce.phpt" role="test" />
       <file name="constructor.phpt" role="test" />
       <file name="eval_include.phpt" role="test" />

--- a/tests/001.phpt
+++ b/tests/001.phpt
@@ -3,7 +3,7 @@ ast_dump() test
 --SKIPIF--
 <?php if (!extension_loaded("ast")) print "skip"; ?>
 --FILE--
-<?php 
+<?php
 
 require __DIR__ . '/../util.php';
 
@@ -70,3 +70,4 @@ AST_STMT_LIST
         returnType: AST_NAME
             flags: NAME_NOT_FQ (1)
             name: "Ret"
+        __declId: 0

--- a/tests/ast_dump_with_linenos.phpt
+++ b/tests/ast_dump_with_linenos.phpt
@@ -43,3 +43,4 @@ AST_STMT_LIST @ 1
                     0: AST_VAR @ 7
                         name: "foo"
         returnType: null
+        __declId: 0

--- a/tests/class.phpt
+++ b/tests/class.phpt
@@ -66,3 +66,5 @@ AST_STMT_LIST
                 uses: null
                 stmts: null
                 returnType: null
+                __declId: 0
+        __declId: 1

--- a/tests/class_consts.phpt
+++ b/tests/class_consts.phpt
@@ -65,3 +65,4 @@ AST_STMT_LIST
                     docComment: /** Doc F */
                     name: "F"
                     value: 6
+        __declId: 0

--- a/tests/class_types.phpt
+++ b/tests/class_types.phpt
@@ -26,34 +26,40 @@ AST_STMT_LIST
         extends: null
         implements: null
         stmts: AST_STMT_LIST
+        __declId: 0
     1: AST_CLASS
         flags: CLASS_ABSTRACT (32)
         name: B
         extends: null
         implements: null
         stmts: AST_STMT_LIST
+        __declId: 1
     2: AST_CLASS
         flags: CLASS_FINAL (4)
         name: C
         extends: null
         implements: null
         stmts: AST_STMT_LIST
+        __declId: 2
     3: AST_CLASS
         flags: CLASS_TRAIT (128)
         name: D
         extends: null
         implements: null
         stmts: AST_STMT_LIST
+        __declId: 3
     4: AST_CLASS
         flags: CLASS_INTERFACE (64)
         name: E
         extends: null
         implements: null
         stmts: AST_STMT_LIST
+        __declId: 4
     5: AST_NEW
         class: AST_CLASS
             flags: CLASS_ANONYMOUS (256)
             extends: null
             implements: null
             stmts: AST_STMT_LIST
+            __declId: 5
         args: AST_ARG_LIST

--- a/tests/closure_numbers.phpt
+++ b/tests/closure_numbers.phpt
@@ -1,0 +1,91 @@
+--TEST--
+Closures should have unique identifiers within parsed code in version 45
+--FILE--
+<?php
+
+require __DIR__ . '/../util.php';
+
+$code = <<<'PHP'
+<?php
+$fn = static function &($a) use ($b) {
+};
+$fn2 = function ($a) {
+};
+PHP;
+echo ast_dump(ast\parse_code($code, $version=45));
+echo ast_dump(ast\parse_code($code, $version=45));
+
+?>
+--EXPECT--
+AST_STMT_LIST
+    0: AST_ASSIGN
+        var: AST_VAR
+            name: "fn"
+        expr: AST_CLOSURE
+            flags: MODIFIER_STATIC | RETURNS_REF (67108865)
+            name: {closure}
+            params: AST_PARAM_LIST
+                0: AST_PARAM
+                    flags: 0
+                    type: null
+                    name: "a"
+                    default: null
+            uses: AST_CLOSURE_USES
+                0: AST_CLOSURE_VAR
+                    flags: 0
+                    name: "b"
+            stmts: AST_STMT_LIST
+            returnType: null
+            __closureId: 0
+    1: AST_ASSIGN
+        var: AST_VAR
+            name: "fn2"
+        expr: AST_CLOSURE
+            flags: 0
+            name: {closure}
+            params: AST_PARAM_LIST
+                0: AST_PARAM
+                    flags: 0
+                    type: null
+                    name: "a"
+                    default: null
+            uses: null
+            stmts: AST_STMT_LIST
+            returnType: null
+            __closureId: 1AST_STMT_LIST
+    0: AST_ASSIGN
+        var: AST_VAR
+            name: "fn"
+        expr: AST_CLOSURE
+            flags: MODIFIER_STATIC | RETURNS_REF (67108865)
+            name: {closure}
+            params: AST_PARAM_LIST
+                0: AST_PARAM
+                    flags: 0
+                    type: null
+                    name: "a"
+                    default: null
+            uses: AST_CLOSURE_USES
+                0: AST_CLOSURE_VAR
+                    flags: 0
+                    name: "b"
+            stmts: AST_STMT_LIST
+            returnType: null
+            __closureId: 0
+    1: AST_ASSIGN
+        var: AST_VAR
+            name: "fn2"
+        expr: AST_CLOSURE
+            flags: 0
+            name: {closure}
+            params: AST_PARAM_LIST
+                0: AST_PARAM
+                    flags: 0
+                    type: null
+                    name: "a"
+                    default: null
+            uses: null
+            stmts: AST_STMT_LIST
+            returnType: null
+            __closureId: 1
+

--- a/tests/closure_numbers.phpt
+++ b/tests/closure_numbers.phpt
@@ -12,8 +12,8 @@ $fn = static function &($a) use ($b) {
 $fn2 = function ($a) {
 };
 PHP;
-echo ast_dump(ast\parse_code($code, $version=45));
-echo ast_dump(ast\parse_code($code, $version=45));
+echo ast_dump(ast\parse_code($code, $version=45)) . "\n";
+echo ast_dump(ast\parse_code($code, $version=45)) . "\n";
 
 ?>
 --EXPECT--
@@ -36,7 +36,7 @@ AST_STMT_LIST
                     name: "b"
             stmts: AST_STMT_LIST
             returnType: null
-            __closureId: 0
+            __declId: 0
     1: AST_ASSIGN
         var: AST_VAR
             name: "fn2"
@@ -52,7 +52,8 @@ AST_STMT_LIST
             uses: null
             stmts: AST_STMT_LIST
             returnType: null
-            __closureId: 1AST_STMT_LIST
+            __declId: 1
+AST_STMT_LIST
     0: AST_ASSIGN
         var: AST_VAR
             name: "fn"
@@ -71,7 +72,7 @@ AST_STMT_LIST
                     name: "b"
             stmts: AST_STMT_LIST
             returnType: null
-            __closureId: 0
+            __declId: 0
     1: AST_ASSIGN
         var: AST_VAR
             name: "fn2"
@@ -87,5 +88,4 @@ AST_STMT_LIST
             uses: null
             stmts: AST_STMT_LIST
             returnType: null
-            __closureId: 1
-
+            __declId: 1

--- a/tests/closure_use_vars.phpt
+++ b/tests/closure_use_vars.phpt
@@ -41,3 +41,4 @@ AST_STMT_LIST
                     name: "d"
             stmts: AST_STMT_LIST
             returnType: null
+            __declId: 0

--- a/tests/named_children.phpt
+++ b/tests/named_children.phpt
@@ -40,3 +40,4 @@ AST_STMT_LIST
                             name: "func"
                         args: AST_ARG_LIST
             returnType: null
+            __declId: 0

--- a/tests/nullable_types.phpt
+++ b/tests/nullable_types.phpt
@@ -40,6 +40,7 @@ AST_STMT_LIST
             type: AST_NAME
                 flags: NAME_NOT_FQ (1)
                 name: "Bar"
+        __declId: 0
     1: AST_FUNC_DECL
         flags: 0
         name: test
@@ -56,6 +57,7 @@ AST_STMT_LIST
         returnType: AST_NULLABLE_TYPE
             type: AST_TYPE
                 flags: TYPE_LONG (4)
+        __declId: 1
     2: AST_FUNC_DECL
         flags: 0
         name: test
@@ -72,3 +74,4 @@ AST_STMT_LIST
         returnType: AST_NULLABLE_TYPE
             type: AST_TYPE
                 flags: TYPE_ARRAY (7)
+        __declId: 2

--- a/tests/prop_doc_comments.phpt
+++ b/tests/prop_doc_comments.phpt
@@ -47,3 +47,4 @@ AST_STMT_LIST
                     docComment: /** docComment $c */
                     name: "c"
                     default: null
+        __declId: 0

--- a/tests/type_hints.phpt
+++ b/tests/type_hints.phpt
@@ -82,6 +82,7 @@ AST_STMT_LIST
         returnType: AST_NAME
             flags: NAME_NOT_FQ (1)
             name: "void"
+        __declId: 0
 AST_STMT_LIST
     0: AST_FUNC_DECL
         flags: 0
@@ -140,3 +141,4 @@ AST_STMT_LIST
         stmts: AST_STMT_LIST
         returnType: AST_TYPE
             flags: TYPE_VOID (18)
+        __declId: 0


### PR DESCRIPTION
POC for issue #58

The output of `var_dump(ast\parse_code('<?php function(){};function(){};', 45));`

will include '__closureId' values starting from 0.
The counter will reset if `parse_code` is called again,
and this approach is meant to work even if PHP is running with multiple threads.

- Additional mutable state can be added to ast_state_info_t

---

- Not sure about what I want to name the field yet
- Maybe there should instead be a third field, `int|array $flags` (Which can control optional behaviors such as adding identifiers, with a list of bit flags or mapping options to values)