### PR TITLE
In version 45+, return an empty statement list in \ast\parse_file for 0 byte file

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ This version normalizes the AST to PHP 7.2 format.
 
 * An `object` type annotation now returns an `AST_TYPE` with `TYPE_OBJECT` flag, rather than
   treating `object` as a class name.
+* `\ast\parse_file` will now consistently return an empty statement list (similar to `\ast\parse_code) if it is passed a zero-byte file.
+  Previously, it would return `null`.
 
 ### 40 (current)
 

--- a/ast.c
+++ b/ast.c
@@ -668,7 +668,13 @@ PHP_FUNCTION(parse_file) {
 	zend_restore_error_handling(&error_handling);
 
 	if (!code) {
-		return;
+		if (version >= 45) {
+			// php_stream_copy_to_mem will return NULL if the file is empty, strangely.
+			// Fix this in new versions, preserve old behavior for version <= 40
+			code = ZSTR_EMPTY_ALLOC();
+		} else {
+			return;
+		}
 	}
 
 	ast = get_ast(code, &arena, filename->val);

--- a/tests/empty_file_parse.phpt
+++ b/tests/empty_file_parse.phpt
@@ -1,0 +1,31 @@
+--TEST--
+ast\parse_file() with empty file
+--FILE--
+<?php
+require __DIR__ . '/../util.php';
+
+echo "Version 40\n";
+$file = ast\parse_file(__DIR__ . '/empty_file.php', $version=40);
+var_dump($file);
+$file = ast\parse_code('', $version=40);
+var_dump($file instanceof ast\Node);
+echo ast_dump($file) . "\n";
+
+echo "Version 45\n";
+$file_45 = ast\parse_file(__DIR__ . '/empty_file.php', $version=45);
+var_dump($file_45 instanceof ast\Node);
+echo ast_dump($file_45) . "\n";
+$file_45 = ast\parse_code('', $version=45);
+var_dump($file_45 instanceof ast\Node);
+echo ast_dump($file_45) . "\n";
+?>
+--EXPECT--
+Version 40
+NULL
+bool(true)
+AST_STMT_LIST
+Version 45
+bool(true)
+AST_STMT_LIST
+bool(true)
+AST_STMT_LIST


### PR DESCRIPTION
This makes \ast\parse_file and \ast\parse_code consistent.

file_get_contents has a similar check of the result of stream_read,
it will return the empty string if it returned null.

After this change,
Versions >= 45 start returning empty STMT_LIST when `\ast\parse_file` is run on a zero-byte file.
Versions <= 40 preserve the pre-existing behavior, continue to return null, to avoid breaking pre-existing code using php-ast. Old releases of Phan rely on php-ast returning null in order to emit PhanEmptyFile.(minor issue).

```