### PR TITLE
Fix ZTS mode

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -66,6 +66,8 @@ typedef struct _ast_flag_info {
 
 ZEND_DECLARE_MODULE_GLOBALS(ast)
 
+ast_str_globals str_globals;
+
 static zend_class_entry *ast_node_ce;
 static zend_class_entry *ast_decl_ce;
 static zend_class_entry *ast_metadata_ce;
@@ -953,12 +955,12 @@ static void ast_build_metadata(zval *result) {
 		object_init_ex(&info_zv, ast_metadata_ce);
 
 		/* kind */
-		ast_update_property_long(&info_zv, AST_G(str_kind), kind, NULL);
+		ast_update_property_long(&info_zv, AST_STR(str_kind), kind, NULL);
 
 		/* name */
 		ZVAL_STRING(&tmp_zv, ast_kind_to_name(kind));
 		Z_TRY_DELREF(tmp_zv);
-		ast_update_property(&info_zv, AST_G(str_name), &tmp_zv, NULL);
+		ast_update_property(&info_zv, AST_STR(str_name), &tmp_zv, NULL);
 
 		/* flags */
 		array_init(&tmp_zv);
@@ -969,11 +971,11 @@ static void ast_build_metadata(zval *result) {
 			}
 		}
 		Z_TRY_DELREF(tmp_zv);
-		ast_update_property(&info_zv, AST_G(str_flags), &tmp_zv, NULL);
+		ast_update_property(&info_zv, AST_STR(str_flags), &tmp_zv, NULL);
 
 		/* flagsCombinable */
 		ZVAL_BOOL(&tmp_zv, flag_info && flag_info->combinable);
-		ast_update_property(&info_zv, AST_G(str_flagsCombinable), &tmp_zv, NULL);
+		ast_update_property(&info_zv, AST_STR(str_flagsCombinable), &tmp_zv, NULL);
 
 		add_index_zval(result, kind, &info_zv);
 	}

--- a/php_ast.h
+++ b/php_ast.h
@@ -24,9 +24,6 @@ extern zend_module_entry ast_module_entry;
 #define AST_NUM_CACHE_SLOTS (2 * 4)
 
 ZEND_BEGIN_MODULE_GLOBALS(ast)
-#define X(str) zend_string *str_ ## str;
-	AST_STR_DEFS
-#undef X
 	void *cache_slots[AST_NUM_CACHE_SLOTS];
 	zval metadata;
 ZEND_END_MODULE_GLOBALS(ast)
@@ -35,7 +32,15 @@ ZEND_EXTERN_MODULE_GLOBALS(ast)
 
 #define AST_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(ast, v)
 
-#define AST_STR(str) AST_G(str)
+typedef struct _ast_str_globals {
+#define X(str) zend_string *str_ ## str;
+	AST_STR_DEFS
+#undef X
+} ast_str_globals;
+
+extern ast_str_globals str_globals;
+
+#define AST_STR(str) str_globals.str
 
 /* Custom ast kind for names */
 #define AST_NAME          2048


### PR DESCRIPTION
The `str_` members in the Zend globals structure are not initialised in request cycles that occur in different threads from the module cycle (due to the TLS storage of Zend globals). So I've shifted them out into a true global variable instead (since they are still needed in the MINIT phase).