### PR TITLE
Fix a php 7.4-dev segfault

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -23,10 +23,10 @@
 #define ast_register_flag_constant(name, value) \
 	REGISTER_NS_LONG_CONSTANT("ast\\flags", name, value, CONST_CS | CONST_PERSISTENT)
 
-#define AST_CACHE_SLOT_KIND     &AST_G(cache_slots)[2 * 0]
-#define AST_CACHE_SLOT_FLAGS    &AST_G(cache_slots)[2 * 1]
-#define AST_CACHE_SLOT_LINENO   &AST_G(cache_slots)[2 * 2]
-#define AST_CACHE_SLOT_CHILDREN &AST_G(cache_slots)[2 * 3]
+#define AST_CACHE_SLOT_KIND     &AST_G(cache_slots)[3 * 0]
+#define AST_CACHE_SLOT_FLAGS    &AST_G(cache_slots)[3 * 1]
+#define AST_CACHE_SLOT_LINENO   &AST_G(cache_slots)[3 * 2]
+#define AST_CACHE_SLOT_CHILDREN &AST_G(cache_slots)[3 * 3]
 
 #define AST_CURRENT_VERSION 60
 

--- a/php_ast.h
+++ b/php_ast.h
@@ -21,7 +21,7 @@ extern zend_module_entry ast_module_entry;
 #include "TSRM.h"
 #endif
 
-#define AST_NUM_CACHE_SLOTS (2 * 4)
+#define AST_NUM_CACHE_SLOTS (3 * 4)
 
 ZEND_BEGIN_MODULE_GLOBALS(ast)
 	void *cache_slots[AST_NUM_CACHE_SLOTS];


### PR DESCRIPTION
The change to add typed properties makes the interpreter access cache_slot[2]
(of `AST_CACHE_SLOT_*`), which segfaults.

This fixes that.

If you see a cleaner way to do this, feel free to implement that instead