### PR TITLE
Fix generating signature types of AST_ARROW_FUNC

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -355,6 +355,9 @@ static inline zend_bool ast_is_name(zend_ast *ast, zend_ast *parent, uint32_t i)
 
 	if (i == 3) {
 		return parent->kind == ZEND_AST_FUNC_DECL || parent->kind == ZEND_AST_CLOSURE
+#if PHP_VERSION_ID >= 70400
+			|| parent->kind == ZEND_AST_ARROW_FUNC
+#endif
 			|| parent->kind == ZEND_AST_METHOD;
 	}
 
@@ -372,6 +375,9 @@ static inline zend_bool ast_is_type(zend_ast *ast, zend_ast *parent, uint32_t i)
 	}
 	if (i == 3) {
 		return parent->kind == ZEND_AST_CLOSURE || parent->kind == ZEND_AST_FUNC_DECL
+#if PHP_VERSION_ID >= 70400
+			|| parent->kind == ZEND_AST_ARROW_FUNC
+#endif
 			|| parent->kind == ZEND_AST_METHOD;
 	}
 	return 0;

--- a/tests/short_arrow_function_return.phpt
+++ b/tests/short_arrow_function_return.phpt
@@ -1,0 +1,99 @@
+--TEST--
+Arrow functions and types ('fn($x) => $x') in PHP 7.4
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70400) die('skip PHP >= 7.4 only'); ?>
+--FILE--
+<?php
+
+require __DIR__ . '/../util.php';
+
+$code = <<<'PHP'
+<?php
+static fn() : int => 1;
+fn(iterable $i) : array => [$i];
+fn(stdClass $param) : \stdClass => $param;
+fn(\stdClass $param) : stdClass => $param;
+PHP;
+
+$node = ast\parse_code($code, $version=70);
+$version_70_repr = ast_dump($node);
+echo $version_70_repr . "\n";
+$node50 = ast\parse_code($code, $version=50);
+$version_50_repr = ast_dump($node50);
+echo "Same representation in version 50/70: ";
+var_export($version_50_repr == $version_70_repr);
+echo "\n";
+?>
+--EXPECT--
+AST_STMT_LIST
+    0: AST_ARROW_FUNC
+        flags: MODIFIER_STATIC (16)
+        name: "{closure}"
+        docComment: null
+        params: AST_PARAM_LIST
+        stmts: AST_RETURN
+            expr: 1
+        returnType: AST_TYPE
+            flags: TYPE_LONG (4)
+        __declId: 0
+    1: AST_ARROW_FUNC
+        flags: 0
+        name: "{closure}"
+        docComment: null
+        params: AST_PARAM_LIST
+            0: AST_PARAM
+                flags: 0
+                type: AST_TYPE
+                    flags: TYPE_ITERABLE (18)
+                name: "i"
+                default: null
+        stmts: AST_RETURN
+            expr: AST_ARRAY
+                flags: ARRAY_SYNTAX_SHORT (3)
+                0: AST_ARRAY_ELEM
+                    flags: 0
+                    value: AST_VAR
+                        name: "i"
+                    key: null
+        returnType: AST_TYPE
+            flags: TYPE_ARRAY (7)
+        __declId: 1
+    2: AST_ARROW_FUNC
+        flags: 0
+        name: "{closure}"
+        docComment: null
+        params: AST_PARAM_LIST
+            0: AST_PARAM
+                flags: 0
+                type: AST_NAME
+                    flags: NAME_NOT_FQ (1)
+                    name: "stdClass"
+                name: "param"
+                default: null
+        stmts: AST_RETURN
+            expr: AST_VAR
+                name: "param"
+        returnType: AST_NAME
+            flags: NAME_FQ (0)
+            name: "stdClass"
+        __declId: 2
+    3: AST_ARROW_FUNC
+        flags: 0
+        name: "{closure}"
+        docComment: null
+        params: AST_PARAM_LIST
+            0: AST_PARAM
+                flags: 0
+                type: AST_NAME
+                    flags: NAME_FQ (0)
+                    name: "stdClass"
+                name: "param"
+                default: null
+        stmts: AST_RETURN
+            expr: AST_VAR
+                name: "param"
+        returnType: AST_NAME
+            flags: NAME_NOT_FQ (1)
+            name: "stdClass"
+        __declId: 3
+Same representation in version 50/70: true


### PR DESCRIPTION
The return/parameter types would have incorrect AST nodes generated
due to the param/return type check not being added for AST_ARROW_FUNC.

Fixes #121