### PR TITLE
Add DIM_ALTERNATIVE_SYNTAX flag for 7.4's $x{$i}

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ ast\flags\ARRAY_SYNTAX_LIST
 
 // Used by ast\AST_ARRAY_ELEM (exclusive)
 ast\flags\ARRAY_ELEM_REF
+
+// Used by ast\AST_DIM (combinable), since PHP 7.4
+ast\flags\DIM_ALTERNATIVE_SYNTAX
 ```
 
 AST node kinds

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,8 @@
  <license uri="https://github.com/nikic/php-ast/blob/master/LICENSE">BSD-3-Clause</license>
  <notes>
 - Fix build error in php 7.4.0alpha3.
+- Add `DIM_ALTERNATIVE_SYNTAX` as a flag of `AST_DIM` for `$x{'offset'}` (for php 7.4+)
+- Bugfix: Make `ast\kind_uses_flags(ast\AST_ARROW_FUNC)` true in php 7.3 and lower.
  </notes>
  <contents>
   <dir name="/">
@@ -81,6 +83,7 @@
       <file name="parse_file_parse_error.phpt" role="test" />
       <file name="parse_file.phpt" role="test" />
       <file name="php74_ast_assign_coalesce.phpt" role="test" />
+      <file name="php74_dim_alternative_syntax.phpt" role="test" />
       <file name="php74_ordinary_class.phpt" role="test" />
       <file name="php74_type_hints.phpt" role="test" />
       <file name="prop_doc_comments.phpt" role="test" />

--- a/tests/metadata.phpt
+++ b/tests/metadata.phpt
@@ -9,6 +9,12 @@ foreach ($metadata as $data) {
     foreach ($data->flags as $flag) {
         $flags[] = substr($flag, strrpos($flag, '\\') + 1);
     }
+    $metadataHasFlags = count($flags) > 0;
+    $kindUsesFlags = ast\kind_uses_flags($data->kind);
+    if ($metadataHasFlags != $kindUsesFlags) {
+        echo "kind_uses_flags for $data->name is unexpectedly " . var_export($kindUsesFlags, true) . "\n";
+    }
+
     echo "$data->name: ";
     if ($data->flagsCombinable) {
         echo "(combinable) ";
@@ -74,7 +80,7 @@ AST_GOTO: []
 AST_BREAK: []
 AST_CONTINUE: []
 AST_CLASS_NAME: []
-AST_DIM: []
+AST_DIM: (combinable) [DIM_ALTERNATIVE_SYNTAX]
 AST_PROP: []
 AST_STATIC_PROP: []
 AST_CALL: []

--- a/tests/php74_ast_assign_coalesce.phpt
+++ b/tests/php74_ast_assign_coalesce.phpt
@@ -26,6 +26,7 @@ AST_STMT_LIST
     1: AST_ASSIGN_OP
         flags: BINARY_COALESCE (%d)
         var: AST_DIM
+            flags: 0
             expr: AST_STATIC_PROP
                 class: AST_NAME
                     flags: NAME_NOT_FQ (%d)

--- a/tests/php74_dim_alternative_syntax.phpt
+++ b/tests/php74_dim_alternative_syntax.phpt
@@ -1,0 +1,29 @@
+--TEST--
+'$x{"offset"}' flag in PHP 7.4
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70400) die('skip PHP >= 7.4 only'); ?>
+--FILE--
+<?php
+
+require __DIR__ . '/../util.php';
+
+$code = <<<'PHP'
+<?php
+var_export($x{'offset'});
+PHP;
+
+$node = ast\parse_code($code, $version=70);
+echo ast_dump($node), "\n";
+?>
+--EXPECTF--
+AST_STMT_LIST
+    0: AST_CALL
+        expr: AST_NAME
+            flags: NAME_NOT_FQ (1)
+            name: "var_export"
+        args: AST_ARG_LIST
+            0: AST_DIM
+                flags: DIM_ALTERNATIVE_SYNTAX (2)
+                expr: AST_VAR
+                    name: "x"
+                dim: "offset"


### PR DESCRIPTION
Fixes #128