### PR TITLE
Update current version in docs to 70

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ Basic usage
 -----------
 
 Code can be parsed using either `ast\parse_code()`, which accepts a code string, or
-`ast\parse_file()`, which accepts a file path. Additionally both functions require a `$version`
-argument to ensure forward-compatibility. The current version is 50.
+`ast\parse_file()`, which accepts a file path. Additionally, both functions require a `$version`
+argument to ensure forward-compatibility. The current version is 70.
 
 ```php
-$ast = ast\parse_code('<?php ...', $version=50);
+$ast = ast\parse_code('<?php ...', $version=70);
 // or
-$ast = ast\parse_file('file.php', $version=50);
+$ast = ast\parse_file('file.php', $version=70);
 ```
 
 The abstract syntax tree returned by these functions consists of `ast\Node` objects.
@@ -109,7 +109,7 @@ $code = <<<'EOC'
 $var = 42;
 EOC;
 
-var_dump(ast\parse_code($code, $version=50));
+var_dump(ast\parse_code($code, $version=70));
 
 // Output:
 object(ast\Node)#1 (4) {
@@ -166,7 +166,7 @@ $code = <<<'EOC'
 $var = 42;
 EOC;
 
-echo ast_dump(ast\parse_code($code, $version=50)), "\n";
+echo ast_dump(ast\parse_code($code, $version=70)), "\n";
 
 // Output:
 AST_STMT_LIST

--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,7 @@
  </lead>
  <date>2019-11-23</date>
  <version>
-  <release>1.0.5</release>
+  <release>1.0.6dev</release>
   <api>1.0.5</api>
  </version>
  <stability>
@@ -29,7 +29,7 @@
  </stability>
  <license uri="https://github.com/nikic/php-ast/blob/master/LICENSE">BSD-3-Clause</license>
  <notes>
-- Add ast\flags\TYPE_FALSE to support PHP 8.0 Union Types.
+- TBD
  </notes>
  <contents>
   <dir name="/">
@@ -120,6 +120,21 @@
  <providesextension>ast</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2019-11-23</date>
+   <version>
+    <release>1.0.5</release>
+    <api>1.0.5</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/nikic/php-ast/blob/master/LICENSE">BSD-3-Clause</license>
+   <notes>
+- Add ast\flags\TYPE_FALSE to support PHP 8.0 Union Types.
+   </notes>
+  </release>
   <release>
    <date>2019-11-10</date>
    <version>

--- a/php_ast.h
+++ b/php_ast.h
@@ -7,7 +7,7 @@
 extern zend_module_entry ast_module_entry;
 #define phpext_ast_ptr &ast_module_entry
 
-#define PHP_AST_VERSION "1.0.5"
+#define PHP_AST_VERSION "1.0.6dev"
 
 #ifdef PHP_WIN32
 #	define PHP_AST_API __declspec(dllexport)


### PR DESCRIPTION
Also, fix grammar nits.

(there should be commas after "Furthermore". More common choices such as
"Next,"/"Then," might be more conventional for installation instructions)