### PR TITLE
Fixed warning in ZTS mode, as the paths are the same

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -145,7 +145,9 @@ build_script:
                 $dname1 = 'php-' + $env:PHP_VER + $ts_part + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
                 if (-not (Test-Path c:\build-cache\$dname1)) {
                         7z x c:\build-cache\$bname -oc:\build-cache
-                        move c:\build-cache\$dname0 c:\build-cache\$dname1
+                        if ($dname0 -ne $dname1) {
+                            move c:\build-cache\$dname0 c:\build-cache\$dname1
+                        }
                 }
                 cd c:\projects\ast
                 $env:PATH = 'c:\build-cache\' + $dname1 + ';' + $env:PATH


### PR DESCRIPTION
It fixes: https://ci.appveyor.com/project/nikic/php-ast/builds/29843461/job/736vhys031jo5vxb#L95