### PR TITLE
Update the policy for removing AST versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,8 +469,7 @@ account for new features in newer PHP versions, or to improve it in other ways. 
 always be made under a new AST version, while previous formats continue to be supported for some
 time.
 
-Old AST versions may be deprecated and subsequently removed. However, AST versions will only be
-removed in conjunction with a version increase of the AST extension from 0.x to 0.(x+1).
+Old AST versions may be deprecated in minor versions and removed in major versions of the AST extension.
 
 A list of currently supported versions is available through `ast\get_supported_versions()`. The
 function accepts a boolean argument that determines whether deprecated versions should be excluded.

--- a/package.xml
+++ b/package.xml
@@ -20,8 +20,8 @@
  </lead>
  <date>2020-02-22</date>
  <version>
-  <release>1.0.6</release>
-  <api>1.0.6</api>
+  <release>1.0.7dev</release>
+  <api>1.0.7dev</api>
  </version>
  <stability>
   <release>stable</release>
@@ -122,6 +122,21 @@
  <providesextension>ast</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2020-02-22</date>
+   <version>
+    <release>1.0.6</release>
+    <api>1.0.6</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/nikic/php-ast/blob/master/LICENSE">BSD-3-Clause</license>
+   <notes>
+- Support TYPE_STATIC for the php 8.0 static return type.
+   </notes>
+  </release>
   <release>
    <date>2019-11-23</date>
    <version>

--- a/php_ast.h
+++ b/php_ast.h
@@ -7,7 +7,7 @@
 extern zend_module_entry ast_module_entry;
 #define phpext_ast_ptr &ast_module_entry
 
-#define PHP_AST_VERSION "1.0.6"
+#define PHP_AST_VERSION "1.0.7dev"
 
 #ifdef PHP_WIN32
 #	define PHP_AST_API __declspec(dllexport)


### PR DESCRIPTION
We're no longer on 0.x. Removing a supported version instead of
deprecating it would be considered a backwards incompatible change by
maintainers of applications using php-ast ^1.x.