### PR TITLE
Support php 8.0 non-capturing catch

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -424,7 +424,7 @@ static inline zend_bool ast_is_type(zend_ast *ast, zend_ast *parent, uint32_t i)
 
 static inline zend_bool ast_is_var_name(zend_ast *ast, zend_ast *parent, uint32_t i) {
 	return (parent->kind == ZEND_AST_STATIC && i == 0)
-		|| (parent->kind == ZEND_AST_CATCH && i == 1);
+		|| (parent->kind == ZEND_AST_CATCH && i == 1 && ast != NULL);
 }
 
 /* Whether this node may need statement list normalization */

--- a/tests/php80_noncapturing_catch.phpt
+++ b/tests/php80_noncapturing_catch.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Non-capturing catches in PHP 8.0
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip PHP >= 8.0 only'); ?>
+--FILE--
+<?php
+
+require __DIR__ . '/../util.php';
+
+$code = <<<'PHP'
+<?php
+try {
+	foo();
+} catch (Exception) {
+	echo "ignoring";
+}
+PHP;
+
+$node = ast\parse_code($code, $version=70);
+echo ast_dump($node), "\n";
+--EXPECTF--
+AST_STMT_LIST
+    0: AST_TRY
+        try: AST_STMT_LIST
+            0: AST_CALL
+                expr: AST_NAME
+                    flags: NAME_NOT_FQ (1)
+                    name: "foo"
+                args: AST_ARG_LIST
+        catches: AST_CATCH_LIST
+            0: AST_CATCH
+                class: AST_NAME_LIST
+                    0: AST_NAME
+                        flags: NAME_NOT_FQ (1)
+                        name: "Exception"
+                var: null
+                stmts: AST_STMT_LIST
+                    0: AST_ECHO
+                        expr: "ignoring"
+        finally: null


### PR DESCRIPTION
Fix a segfault, check if the ast for the variable name is not null