### PR TITLE
relax tests for 8.0 master

### DIFF
--- a/tests/parse_code_parse_error.phpt
+++ b/tests/parse_code_parse_error.phpt
@@ -18,11 +18,11 @@ try {
 
 ?>
 --EXPECTF--
-ParseError: syntax error, unexpected '&', expecting end of file in string code:1
+ParseError: syntax error, unexpected %s&%s expecting end of file in string code:1
 Stack trace:
 #0 %s(%d): ast\parse_code('%s', %d)
 #1 {main}
-ParseError: syntax error, unexpected '&', expecting end of file in file.php:1
+ParseError: syntax error, unexpected %s&%s expecting end of file in file.php:1
 Stack trace:
 #0 %s(%d): ast\parse_code('%s', %d, 'file.php')
 #1 {main}

--- a/tests/parse_file_parse_error.phpt
+++ b/tests/parse_file_parse_error.phpt
@@ -11,7 +11,7 @@ try {
 
 ?>
 --EXPECTF--
-ParseError: syntax error, unexpected ')' in %stests/invalid_file.php:3
+ParseError: syntax error, unexpected %s)%s in %stests/invalid_file.php:3
 Stack trace:
 #0 %s(%d): ast\parse_file('%s', %d)
 #1 {main}


### PR DESCRIPTION
Seems related to https://github.com/php/php-src/commit/55a15f32ced0bd2467e6dec0c1287a4f11b1852f#diff-ed9881373b14743d80893f15edb5675e

This is to fix  `unexpected '&'` vs `unexpected token "&"`