### PR TITLE
Make AST version 80 the current AST version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,16 +491,17 @@ function accepts a boolean argument that determines whether deprecated versions 
 In the following the changes in the respective AST versions, as well as their current support state,
 are listed.
 
-### 80 (experimental)
+### 80 (current)
 
-Available since 1.0.7 (XXX).
+Supported since 1.0.10 (XXX).
 
 * `mixed` type hints are now reported as an `AST_TYPE` with type `TYPE_MIXED` instead of an `AST_NAME`.
-* `AST_CLASS_CONST_GROUP` nodes are emitted for all class constant declarations.
+* `AST_CLASS_CONST_GROUP` nodes are emitted for class constant declarations wrapping the `AST_CLASS_CONST_DECL` and any attributes.
+  Previously, `AST_CLASS_CONST_DECL` would be emitted.
 * `AST_PARAM`, `AST_CLASS_DECL`, `AST_METHOD`, `AST_PROP_DECL`, `AST_CLOSURE`, `AST_FUNC_DECL`, and `AST_ARROW_FUNC` nodes
   now contain an attributes child.
 
-### 70 (current)
+### 70 (stable)
 
 Supported since 1.0.1 (2019-02-11).
 

--- a/ast.c
+++ b/ast.c
@@ -28,7 +28,7 @@
 #define AST_CACHE_SLOT_LINENO   &AST_G(cache_slots)[3 * 2]
 #define AST_CACHE_SLOT_CHILDREN &AST_G(cache_slots)[3 * 3]
 
-#define AST_CURRENT_VERSION 70
+#define AST_CURRENT_VERSION 80
 
 /* Additional flags for BINARY_OP */
 #define AST_BINARY_IS_GREATER 256

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,7 @@
  <license uri="https://github.com/nikic/php-ast/blob/master/LICENSE">BSD-3-Clause</license>
  <notes>
 - Support attributes syntax change (`#[...]`) in php 8.0.0RC1.
+- Change the current AST version from 70 to 80. AST version 80 is no longer experimental.
  </notes>
  <contents>
   <dir name="/">


### PR DESCRIPTION
This will stop being experimental in 1.0.10.

Closes #178