### PR TITLE
Fix bug preventing parsing attributes on AST_CLASS

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -526,7 +526,7 @@ static inline zend_ast **ast_get_children(zend_ast *ast, uint32_t *count) {
 	if (ast_kind_is_decl(ast->kind)) {
 		zend_ast_decl *decl = (zend_ast_decl *) ast;
 #if PHP_VERSION_ID >= 80000
-		*count = decl->kind == ZEND_AST_CLASS ? 4 : 5;
+		*count = 5;
 #else
 		*count = decl->kind == ZEND_AST_CLASS ? 3 : 4;
 #endif
@@ -662,7 +662,7 @@ static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, ast_state_info_t 
 					}
 					break;
 				case ZEND_AST_CLASS:
-					if (i == 3) {
+					if (i >= 3) {
 						continue;
 					}
 					break;
@@ -671,6 +671,10 @@ static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, ast_state_info_t 
 						continue;
 					}
 					break;
+			}
+		} else {
+			if (ast_kind == ZEND_AST_CLASS && i == 3) {
+				continue;
 			}
 		}
 #endif

--- a/ast_data.c
+++ b/ast_data.c
@@ -280,7 +280,8 @@ zend_string *ast_kind_child_name(zend_ast_kind kind, uint32_t child) {
 				case 0: return AST_STR(str_extends);
 				case 1: return AST_STR(str_implements);
 				case 2: return AST_STR(str_stmts);
-				case 3: return AST_STR(str_attributes);
+				case 3: return AST_STR(str___PLACEHOLDER__);
+				case 4: return AST_STR(str_attributes);
 			}
 			return NULL;
 		case ZEND_AST_MAGIC_CONST:

--- a/ast_str_defs.h
+++ b/ast_str_defs.h
@@ -19,6 +19,7 @@
 	X(attributes) \
 	X(extends) \
 	X(implements) \
+	X(__PLACEHOLDER__) \
 	X(expr) \
 	X(var) \
 	X(offset) \

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,7 @@
  <license uri="https://github.com/nikic/php-ast/blob/master/LICENSE">BSD-3-Clause</license>
  <notes>
 - Support attributes syntax change (`#[...]`) in php 8.0.0RC1.
+- Fix a bug that caused attributes to fail to parse on `ast\AST_CLASS` declarations.
  </notes>
  <contents>
   <dir name="/">

--- a/scripts/generate_ast_data.php
+++ b/scripts/generate_ast_data.php
@@ -58,7 +58,9 @@ $names = [
     'ZEND_AST_CLOSURE' => $funcNames,
     'ZEND_AST_METHOD' => $funcNames,
     'ZEND_AST_ARROW_FUNC' => $funcNames,
-    'ZEND_AST_CLASS' => ['extends', 'implements', 'stmts', 'attributes'],
+    // In php 8.0, the 4th child of AST_CLASS is always null.
+    // (so that declarations always have attributes at index 4?)
+    'ZEND_AST_CLASS' => ['extends', 'implements', 'stmts', '__PLACEHOLDER__', 'attributes'],
 
     /* 0 child nodes */
     'ZEND_AST_MAGIC_CONST' => [],

--- a/tests/attributes_02.phpt
+++ b/tests/attributes_02.phpt
@@ -175,7 +175,13 @@ AST_STMT_LIST
                                 name: "Attr5"
                             args: AST_ARG_LIST
                 __declId: 0
-        attributes: null
+        attributes: AST_ATTRIBUTE_LIST
+            0: AST_ATTRIBUTE_GROUP
+                0: AST_ATTRIBUTE
+                    class: AST_NAME
+                        flags: NAME_FQ (%d)
+                        name: "SomeAttribute"
+                    args: AST_ARG_LIST
         __declId: 1
     2: AST_FUNC_DECL
         flags: 0


### PR DESCRIPTION
Unexpectedly, the attributes were found at index 4, not index 3.
Index 3 was always null.
Use a different name to make it obvious if refactoring bugs cause the
placeholder index to have child nodes get unintentionally emitted.

Tests pass locally in 8.0, and in 7.0-7.4 in travis