### PR TITLE
Update zpp test expectations for php 8.

### DIFF
--- a/tests/zpp_errors.phpt
+++ b/tests/zpp_errors.phpt
@@ -13,8 +13,8 @@ try { ast\kind_uses_flags(); }
 catch (TypeError $e) { echo $e->getMessage(), "\n"; }
 
 ?>
---EXPECT--
-ast\parse_code() expects at least 1 parameter, 0 given
-ast\parse_file() expects at least 1 parameter, 0 given
-ast\get_kind_name() expects exactly 1 parameter, 0 given
-ast\kind_uses_flags() expects exactly 1 parameter, 0 given
+--EXPECTF--
+ast\parse_code() expects at least 1 %s, 0 given
+ast\parse_file() expects at least 1 %s, 0 given
+ast\get_kind_name() expects exactly 1 %s, 0 given
+ast\kind_uses_flags() expects exactly 1 %s, 0 given


### PR DESCRIPTION
PHP 8 refers to arguments as "argument". This changed recently.
PHP 7 refers to arguments as "parameter".

PHP 8 travis tests should succeed in tomorrow's travis nightly build - php-src was changed today to avoid the gap that was causing php-ast to fail to parse attributes on nodes of kind AST_CLASS