### PR TITLE
Fix missing break in switch statement

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -863,6 +863,7 @@ static void ast_to_zval(zval *zv, zend_ast *ast, ast_state_info_t *state) {
 				ast_to_zval(zv, ast->child[0], state);
 				return;
 			}
+			break;
 #endif
 #if PHP_VERSION_ID >= 70400
 		case ZEND_AST_PROP_GROUP:


### PR DESCRIPTION
This is currently harmless because 80 > 70,
but would be a potential problem if refactoring