### PR TITLE
Disable Xdebug on nightly; travis does not yet support php 8.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ indent_style = space
 [*.{md,php,phpt}]
 indent_size = 4
 indent_style = space
+[*.yml]
+indent_size = 2
+indent_style = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,14 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  # https://travis-ci.community/t/php-8-0-missing/10132
+  # - 8.0snapshot
   - nightly
 
 before_script:
+  # Disable Xdebug because it should be unrelated to the functionality of php-ast being tested.
+  # Xdebug will have issues as PHP 8.1.0-dev/nightly's internal functionality changes.
+  - phpenv config-rm xdebug.ini || true
   - phpize
   - ./configure
   - make


### PR DESCRIPTION
If tests don't work with Xdebug, that's an issue with Xdebug.
(in php 8.1.0-dev, it's broken, which is normal due to rapid changes)

Seen in travis logs for #192 