### PR TITLE
Allow dynamic properties (e.g. endLineno) without deprecation notice in ast\Node

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -13,6 +13,10 @@
 #include "zend_language_parser.h"
 #include "zend_exceptions.h"
 #include "zend_smart_str.h"
+#if PHP_VERSION_ID >= 80200
+/* Used for AllowDynamicProperties */
+#include "zend_attributes.h"
+#endif
 
 #ifndef ZEND_ARG_INFO_WITH_DEFAULT_VALUE
 #define ZEND_ARG_INFO_WITH_DEFAULT_VALUE(pass_by_ref, name, default_value) \
@@ -1518,6 +1522,10 @@ PHP_MINIT_FUNCTION(ast) {
 	ast_declare_property(ast_node_ce, AST_STR(str_flags), &zv_null);
 	ast_declare_property(ast_node_ce, AST_STR(str_lineno), &zv_null);
 	ast_declare_property(ast_node_ce, AST_STR(str_children), &zv_null);
+#ifdef ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES
+	zend_add_class_attribute(ast_node_ce, zend_ce_allow_dynamic_properties->name, 0);
+	ast_node_ce->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+#endif
 
 	INIT_CLASS_ENTRY(tmp_ce, "ast\\Metadata", NULL);
 	ast_metadata_ce = zend_register_internal_class(&tmp_ce);

--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,7 @@
  </stability>
  <license uri="https://github.com/nikic/php-ast/blob/master/LICENSE">BSD-3-Clause</license>
  <notes>
-- TBD
+- Allow ast\Node to have dynamic properties without emitting a notice in PHP 8.2.
  </notes>
  <contents>
   <dir name="/">
@@ -115,6 +115,7 @@
       <file name="php81_final_class_const.phpt" role="test" />
       <file name="php81_intersection_types.phpt" role="test" />
       <file name="php81_readonly.phpt" role="test" />
+      <file name="php82_metadata.phpt" role="test" />
       <file name="prop_doc_comments.phpt" role="test" />
       <file name="short_arrow_function.phpt" role="test" />
       <file name="short_arrow_function_return.phpt" role="test" />

--- a/tests/php82_metadata.phpt
+++ b/tests/php82_metadata.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Dynamic property support in php 8.2+
+--SKIPIF--
+<?php if (!class_exists('AllowDynamicProperties')) die('skip PHP >=8.2 only'); ?>
+--FILE--
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 'stderr');
+
+function dump($x) {
+    var_export($x);
+    echo "\n";
+}
+
+function dump_attributes(string $class) {
+    echo "Attributes of $class:\n";
+    foreach ((new ReflectionClass($class))->getAttributes() as $attribute) {
+        echo "- " . $attribute->getName() . "\n";
+    }
+}
+
+$node = new ast\Node();
+$node->undeclaredDynamic = 123;
+dump($node);
+$metadata = new ast\Metadata();
+$metadata->undeclaredDynamic = 123;
+dump($metadata);
+dump_attributes(ast\Node::class);
+dump_attributes(ast\Metadata::class);
+--EXPECTF--
+ast\Node::__set_state(array(
+   'kind' => NULL,
+   'flags' => NULL,
+   'lineno' => NULL,
+   'children' => NULL,
+   'undeclaredDynamic' => 123,
+))
+Deprecated: Creation of dynamic property ast\Metadata::$undeclaredDynamic is deprecated in %sphp82_metadata.php on line 21
+ast\Metadata::__set_state(array(
+   'kind' => NULL,
+   'name' => NULL,
+   'flags' => NULL,
+   'flagsCombinable' => NULL,
+   'undeclaredDynamic' => 123,
+))
+Attributes of ast\Node:
+- AllowDynamicProperties
+Attributes of ast\Metadata:


### PR DESCRIPTION
(But use the default deprecation behavior for ast\Metadata)

1. php-ast itself sets the dynamic property on endLineno right now,
   causing deprecation notices in PHP 8.2.
   Because all declaration types are associative arrays(not lists),
   a future AST version number may add this as a property of
   $node->children instead to avoid this notice.
2. WeakMap is only available in PHP 8.0+ (and WeakReference 7.4),
   but https://github.com/phan/phan supports PHP 7.2+.

   Having a Phan version (or external plugins) that can work (and be fast) with a wider range of php versions is useful for organizations trying to detect uses of undeclared properties that need to migrate.
3. Because some nodes make `$node->children` a list,
   applications such as Phan using php-ast can't associate string keys
   with that.
   (e.g. to mark nodes that were already processed in a certain step)

   https://github.com/nikic/php-parser solves that by adding
   `attributes`, `setAttribute`, `getAttribute`, etc. separately from
   children, but php-ast currently doesn't currently have an attributes node.
   That may be useful to add (and to remove the AllowsDynamicProperty annotation in an incompatible php-ast major release)

   That may be worth it in a future release.
4. When processing a large number of ast nodes in a large number of
   files, the deprecation notices have a noticeable performance impact,
   even when suppressed.

Related to #214

Phan has a lot of uses of dynamic properties - e.g.
- to associate a hash with a node to check if two nodes are equivalent AST trees (probabalistically)
- to check (when using the polyfill fallback for php-ast) if syntax that's deprecated (unparenthesized ambiguous `?:` syntax, trailing commas).
- to check if an AST node is already normalized to an easier to analyze form
- to check for infinite recursion
- to track information about a function's AST_STMT_LIST such as the set of used goto labels (can probably be migrated?)
- various others


```c
src/Phan/AST/ASTHasher.php
66:        // @phan-suppress-next-line PhanUndeclaredProperty
67-        return $node->hash ?? ($node->hash = self::computeHash($node));

src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
1046:                    // @phan-suppress-next-line PhanUndeclaredProperty
1047-                    $result->is_not_parenthesized = true;
--
2096:            // @phan-suppress-next-line PhanUndeclaredProperty
2097-            $result->polyfill_has_trailing_comma = true;
--
```