### PR TITLE
Update php versions tested in CI, prepare the 1.0.15 release

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,22 +32,42 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.0.3
+                  PHP_VER: 8.1.0
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.0.3
+                  PHP_VER: 8.1.0
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.0.3
+                  PHP_VER: 8.1.0
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.0.3
+                  PHP_VER: 8.1.0
+                  TS: 0
+                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                  ARCH: x86
+                  VC: vs16
+                  PHP_VER: 8.0.13
+                  TS: 1
+                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                  ARCH: x64
+                  VC: vs16
+                  PHP_VER: 8.0.13
+                  TS: 1
+                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                  ARCH: x86
+                  VC: vs16
+                  PHP_VER: 8.0.13
+                  TS: 0
+                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                  ARCH: x64
+                  VC: vs16
+                  PHP_VER: 8.0.13
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
                   ARCH: x64
@@ -112,42 +132,42 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15
-                  PHP_VER: 7.3.25
+                  PHP_VER: 7.3.33
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15
-                  PHP_VER: 7.3.27
+                  PHP_VER: 7.3.33
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.3.27
+                  PHP_VER: 7.3.33
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.3.27
+                  PHP_VER: 7.3.33
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15
-                  PHP_VER: 7.4.16
+                  PHP_VER: 7.4.26
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15
-                  PHP_VER: 7.4.16
+                  PHP_VER: 7.4.26
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.4.16
+                  PHP_VER: 7.4.26
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.4.16
+                  PHP_VER: 7.4.26
                   TS: 1
 
 build_script:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
          - PHP_VERSION: '7.3'
          - PHP_VERSION: '7.4'
          - PHP_VERSION: '8.0'
-         - PHP_VERSION: '8.1.0beta1'
+         - PHP_VERSION: '8.1.0RC6'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/ast.c
+++ b/ast.c
@@ -50,6 +50,7 @@
 #define ast_register_flag_constant(name, value) \
 	REGISTER_NS_LONG_CONSTANT("ast\\flags", name, value, CONST_CS | CONST_PERSISTENT)
 
+// The number of cache slots there are must be the same as AST_NUM_CACHE_SLOTS in php_ast.h
 #define AST_CACHE_SLOT_KIND     &AST_G(cache_slots)[3 * 0]
 #define AST_CACHE_SLOT_FLAGS    &AST_G(cache_slots)[3 * 1]
 #define AST_CACHE_SLOT_LINENO   &AST_G(cache_slots)[3 * 2]

--- a/ci/test_dockerized.sh
+++ b/ci/test_dockerized.sh
@@ -10,6 +10,7 @@ fi
 # -u fail for undefined variables
 set -xeu
 PHP_VERSION=$1
-DOCKER_IMAGE=php-ast-$PHP_VERSION-test-runner
+# uppercase is not allowed in image names, only in tags
+DOCKER_IMAGE=php-ast-test-runner:$PHP_VERSION
 docker build --build-arg="PHP_VERSION=$PHP_VERSION" --tag="$DOCKER_IMAGE" -f ci/Dockerfile .
 docker run --rm $DOCKER_IMAGE ci/test_inner.sh

--- a/package.xml
+++ b/package.xml
@@ -18,10 +18,10 @@
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2021-07-24</date>
+ <date>2021-11-27</date>
  <version>
-  <release>1.0.15dev</release>
-  <api>1.0.15dev</api>
+  <release>1.0.15</release>
+  <api>1.0.15</api>
  </version>
  <stability>
   <release>devel</release>

--- a/php_ast.h
+++ b/php_ast.h
@@ -7,7 +7,7 @@
 extern zend_module_entry ast_module_entry;
 #define phpext_ast_ptr &ast_module_entry
 
-#define PHP_AST_VERSION "1.0.15-dev"
+#define PHP_AST_VERSION "1.0.15"
 
 #ifdef PHP_WIN32
 #	define PHP_AST_API __declspec(dllexport)
@@ -23,6 +23,7 @@ extern zend_module_entry ast_module_entry;
 
 // PHP 7.4 added a 3rd cache slot for property_info
 // and expects cache_slot[2] to be null.
+// There are 4 entries in ast.c in `AST_CACHE_SLOT_*`
 #define AST_NUM_CACHE_SLOTS (3 * 4)
 
 ZEND_BEGIN_MODULE_GLOBALS(ast)


### PR DESCRIPTION
PHP '8.1' isn't published yet on docker hub.

Start testing with php 8.1 in appveyor