### PR TITLE
Allow extending the Node class

### DIFF
--- a/ast.stub.php
+++ b/ast.stub.php
@@ -39,7 +39,9 @@ class Node
     }
 
     public static function parseCode(string $code, int $version, string $filename = 'string code'): static {
+    }
 
+    public static function parseFile(string $filename, int $version): static {
     }
 }
 

--- a/ast.stub.php
+++ b/ast.stub.php
@@ -37,5 +37,9 @@ class Node
 {
     public function __construct(?int $kind = null, ?int $flags = null, ?array $children = null, ?int $lineno = null) {
     }
+
+    public static function parseCode(string $code, int $version, string $filename = 'string code'): static {
+
+    }
 }
 

--- a/ast_arginfo.h
+++ b/ast_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bd6cdcf553c8e2d0fa06a42f9ff86e716544f817 */
+ * Stub hash: 938fe8988fbcf94dd83623b485367a9d77446be2 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_ast_parse_code, 0, 2, ast\\Node, 0)
 	ZEND_ARG_TYPE_INFO(0, code, IS_STRING, 0)
@@ -34,6 +34,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ast_Node___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, lineno, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ast_Node_parseCode, 0, 2, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, code, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, version, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 0, "\'string code\'")
+ZEND_END_ARG_INFO()
+
 
 ZEND_FUNCTION(parse_code);
 ZEND_FUNCTION(parse_file);
@@ -42,6 +48,7 @@ ZEND_FUNCTION(kind_uses_flags);
 ZEND_FUNCTION(get_metadata);
 ZEND_FUNCTION(get_supported_versions);
 ZEND_METHOD(ast_Node, __construct);
+ZEND_METHOD(ast_Node, parseCode);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -57,5 +64,6 @@ static const zend_function_entry ext_functions[] = {
 
 static const zend_function_entry class_ast_Node_methods[] = {
 	ZEND_ME(ast_Node, __construct, arginfo_class_ast_Node___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(ast_Node, parseCode, arginfo_class_ast_Node_parseCode, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_FE_END
 };

--- a/ast_arginfo.h
+++ b/ast_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 938fe8988fbcf94dd83623b485367a9d77446be2 */
+ * Stub hash: ee607cbbad2f3414a7cbd756e9db54054c29023c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_ast_parse_code, 0, 2, ast\\Node, 0)
 	ZEND_ARG_TYPE_INFO(0, code, IS_STRING, 0)
@@ -40,6 +40,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ast_Node_parseCode, 0, 2, 
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 0, "\'string code\'")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ast_Node_parseFile, 0, 2, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, version, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 
 ZEND_FUNCTION(parse_code);
 ZEND_FUNCTION(parse_file);
@@ -49,6 +54,7 @@ ZEND_FUNCTION(get_metadata);
 ZEND_FUNCTION(get_supported_versions);
 ZEND_METHOD(ast_Node, __construct);
 ZEND_METHOD(ast_Node, parseCode);
+ZEND_METHOD(ast_Node, parseFile);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -65,5 +71,6 @@ static const zend_function_entry ext_functions[] = {
 static const zend_function_entry class_ast_Node_methods[] = {
 	ZEND_ME(ast_Node, __construct, arginfo_class_ast_Node___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(ast_Node, parseCode, arginfo_class_ast_Node_parseCode, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(ast_Node, parseFile, arginfo_class_ast_Node_parseFile, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_FE_END
 };

--- a/tests/node_parse_code.phpt
+++ b/tests/node_parse_code.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Node::parseCode() on valid code
+--FILE--
+<?php
+
+require __DIR__ . '/../util.php';
+
+$code = <<<'PHP'
+<?php
+
+return 123;
+PHP;
+
+echo ast_dump(ast\Node::parseCode($code, $version=50)), "\n";
+
+?>
+--EXPECT--
+AST_STMT_LIST
+    0: AST_RETURN
+        expr: 123

--- a/tests/node_parse_code_subclass.phpt
+++ b/tests/node_parse_code_subclass.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Node::parseCode() on valid code with subclass
+--FILE--
+<?php
+
+require __DIR__ . '/../util.php';
+
+class MyNode extends \ast\Node {
+}
+
+$code = <<<'PHP'
+<?php
+
+return 123;
+PHP;
+
+echo get_class(MyNode::parseCode($code, $version=50)), "\n";
+
+?>
+--EXPECT--
+MyNode

--- a/tests/node_parse_file.phpt
+++ b/tests/node_parse_file.phpt
@@ -1,0 +1,15 @@
+--TEST--
+ast\Node::parseFile() on valid file
+--FILE--
+<?php
+
+require __DIR__ . '/../util.php';
+
+$ast = ast\Node::parseFile(__DIR__ . '/valid_file.php', $version=50);
+echo ast_dump($ast);
+
+?>
+--EXPECT--
+AST_STMT_LIST
+    0: AST_RETURN
+        expr: 123


### PR DESCRIPTION
This PR adds the ability to extend the `Node` class and parse code into your own classes. The idea is to offer a [similar API to the tokenizer extension](https://www.php.net/manual/en/phptoken.tokenize.php):

```php
<?php

class MyNode extends \ast\Node
{
    public bool $myFlag = false;
}

$ast = MyNode::parseCode('<?php echo "hello, world!";', 90);

$ast->myFlag = true;

var_dump($ast);
```

<details>
<summary>Example output</summary>

```
object(MyNode)#1 (5) {
  ["kind"]=>
  int(132)
  ["flags"]=>
  int(0)
  ["lineno"]=>
  int(1)
  ["children"]=>
  array(1) {
    [0]=>
    object(MyNode)#2 (5) {
      ["kind"]=>
      int(283)
      ["flags"]=>
      int(0)
      ["lineno"]=>
      int(1)
      ["children"]=>
      array(1) {
        ["expr"]=>
        string(13) "hello, world!"
      }
      ["myFlag"]=>
      bool(false)
    }
  }
  ["myFlag"]=>
  bool(true)
}
```

</details>

This solves a similar problem as #217 but in a different way. Compared to dynamic properties this approach lets you add methods, constants, interfaces, etc. as well and everything can be statically analyzed properly.