### PR TITLE
Fix test failures seen in php 8.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,8 @@ jobs:
          - PHP_VERSION: '7.3'
          - PHP_VERSION: '7.4'
          - PHP_VERSION: '8.0'
-         - PHP_VERSION: '8.1.0RC6'
+         - PHP_VERSION: '8.1'
+         - PHP_VERSION: '8.2.0beta2'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/tests/php82_metadata.phpt
+++ b/tests/php82_metadata.phpt
@@ -28,7 +28,7 @@ dump($metadata);
 dump_attributes(ast\Node::class);
 dump_attributes(ast\Metadata::class);
 --EXPECTF--
-ast\Node::__set_state(array(
+%Sast\Node::__set_state(array(
    'kind' => NULL,
    'flags' => NULL,
    'lineno' => NULL,
@@ -36,7 +36,7 @@ ast\Node::__set_state(array(
    'undeclaredDynamic' => 123,
 ))
 Deprecated: Creation of dynamic property ast\Metadata::$undeclaredDynamic is deprecated in %sphp82_metadata.php on line 21
-ast\Metadata::__set_state(array(
+%Sast\Metadata::__set_state(array(
    'kind' => NULL,
    'name' => NULL,
    'flags' => NULL,


### PR DESCRIPTION
Fix bug where ZEND_AST_ARROW_FUNC output for 'stmts' in php 8.2 did not match
earlier php versions, which would affect tools using php-ast.

Handle var_export's output changing to always be fully qualified in test
output

And start running tests in php 8.2.