### PR TITLE
Fix redundant call to ast_to_zval

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -795,7 +795,7 @@ static void ast_fill_children_ht(HashTable *ht, zend_ast *ast, ast_state_info_t 
 				/* (This is still different from regular functions, which have AST_STMT_LIST) */
 				/* TODO: In a new node type, remove the ZEND_AST_RETURN node instead. */
 				zval tmp;
-				ast_to_zval(&tmp, child, state);
+				ZVAL_COPY_VALUE(&tmp, &child_zv);
 				ast_create_virtual_node_ex(
 					&child_zv, ZEND_AST_RETURN, 0, zend_ast_get_lineno(child), state, 1, &tmp);
 			}

--- a/package.xml
+++ b/package.xml
@@ -122,6 +122,7 @@
       <file name="prop_doc_comments.phpt" role="test" />
       <file name="short_arrow_function.phpt" role="test" />
       <file name="short_arrow_function_return.phpt" role="test" />
+      <file name="short_arrow_function_decl_id.phpt" role="test" />
       <file name="stmt_list.phpt" role="test" />
       <file name="try_catch_finally.phpt" role="test" />
       <file name="type_hints.phpt" role="test" />

--- a/tests/short_arrow_function_decl_id.phpt
+++ b/tests/short_arrow_function_decl_id.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Nested arrow functions in PHP 7.4
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70400) die('skip PHP >= 7.4 only'); ?>
+--FILE--
+<?php
+
+require __DIR__ . '/../util.php';
+
+$code = <<<'PHP'
+<?php
+$cb = fn() => fn() => $undef;
+PHP;
+
+$node = ast\parse_code($code, $version=85);
+echo ast_dump($node) . "\n";
+?>
+--EXPECT--
+AST_STMT_LIST
+    0: AST_ASSIGN
+        var: AST_VAR
+            name: "cb"
+        expr: AST_ARROW_FUNC
+            flags: 0
+            name: "{closure}"
+            docComment: null
+            params: AST_PARAM_LIST
+            stmts: AST_RETURN
+                expr: AST_ARROW_FUNC
+                    flags: 0
+                    name: "{closure}"
+                    docComment: null
+                    params: AST_PARAM_LIST
+                    stmts: AST_RETURN
+                        expr: AST_VAR
+                            name: "undef"
+                    returnType: null
+                    attributes: null
+                    __declId: 0
+            returnType: null
+            attributes: null
+            __declId: 1


### PR DESCRIPTION
I noticed in 1.1.0dev that the __declId did not match a polyfill
when short arrow functions were nested.
ast_to_zval was already being called on the above lines in ast.c,
calling it again would create `ast\Node` instances again.