### PR TITLE
Update the download link for php-ast

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installation
 **Windows**: Download a [prebuilt Windows DLL](https://downloads.php.net/~windows/pecl/releases/ast/)
 and move it into the `ext/` directory of your PHP installation. Furthermore, add
 `extension=php_ast.dll` to your `php.ini` file.
-(The [php-ast PECL page](https://downloads.php.net/~windows/pecl/releases/ast/) also links to the same DLLs for Windows)
+(The [php-ast PECL page](https://downloads.php.net/~windows/pecl/releases/ast/) also links to the same DLLs for Windows.)
 
 **Unix (PECL)**: Run `pecl install ast` and add `extension=ast.so` to your `php.ini`.
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ Table of Contents
 Installation
 ------------
 
-**Windows**: Download a [prebuilt Windows DLL](http://windows.php.net/downloads/pecl/releases/ast/)
-and move it into the `ext/` directory of your PHP installation. Furthermore add
+**Windows**: Download a [prebuilt Windows DLL](https://downloads.php.net/~windows/pecl/releases/ast/)
+and move it into the `ext/` directory of your PHP installation. Furthermore, add
 `extension=php_ast.dll` to your `php.ini` file.
+(The [php-ast PECL page](https://downloads.php.net/~windows/pecl/releases/ast/) also links to the same DLLs for Windows)
 
 **Unix (PECL)**: Run `pecl install ast` and add `extension=ast.so` to your `php.ini`.
 


### PR DESCRIPTION
This changed to https://downloads.php.net/~windows/pecl/releases/ast/ and may change again.

https://pecl.php.net/package/ast should have the most up to date links and be easier to read.

Related to #236