### PR TITLE
Add PIE support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "nikic/php-ast",
+    "type": "php-ext",
+    "license": "BSD-3-Clause",
+    "description": "Extension exposing PHP 7 abstract syntax tree ",
+    "require": {
+        "php": ">= 7.2.0"
+    },
+    "php-ext": {
+        "extension-name": "ast"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "nikic/php-ast",
     "type": "php-ext",
     "license": "BSD-3-Clause",
-    "description": "Extension exposing PHP 7 abstract syntax tree ",
+    "description": "Extension exposing PHP 7 abstract syntax tree",
     "require": {
         "php": ">= 7.2.0"
     },


### PR DESCRIPTION
Adds support for [PIE](https://github.com/php/pie).

Once merged, a maintainer would need to add this repo's URL to https://packagist.org/packages/submit :)

More info/documentation can be read on: https://github.com/php/pie/blob/main/docs/extension-maintainers.md