### PR TITLE
relax test expectations

### DIFF
--- a/tests/parse_file_not_existing.phpt
+++ b/tests/parse_file_not_existing.phpt
@@ -11,7 +11,7 @@ try {
 
 ?>
 --EXPECTF--
-RuntimeException: ast\parse_file(%stests/non_existing_file.php): %sailed to open stream: No such file or directory in %s:%d
+RuntimeException: ast\parse_file(%sailed to open stream: No such file or directory in %s:%d
 Stack trace:
 #0 %s(%d): ast\parse_file('%s', %d)
 #1 {main}


### PR DESCRIPTION
Test failing with PHP 8.6.0alpha3

```
========DIFF========
001- RuntimeException: ast\parse_file(%stests/non_existing_file.php): %sailed to open stream: No such file or directory in %s:%d
001+ RuntimeException: ast\parse_file(): Failed to open stream: No such file or directory in /work/GIT/pecl-and-ext/ast/tests/parse_file_not_existing.php:4
     Stack trace:
     #0 %s(%d): ast\parse_file('%s', %d)
     #1 {main}
========DONE========
FAIL ast\parse_file() on file that does not exist [tests/parse_file_not_existing.phpt] 

```